### PR TITLE
Add dactyl manuform (handwires 2020 print) + VIA support

### DIFF
--- a/keyboards/dactyl_manuform/keymaps/via/keymap.c
+++ b/keyboards/dactyl_manuform/keymaps/via/keymap.c
@@ -50,22 +50,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 [_QWERTY] = LAYOUT(
   // left hand
-   KC_GRV,   KC_1,    KC_2,    KC_3,   KC_4,   KC_5,   QK_BOOT,
+   KC_GRV,   KC_1,    KC_2,    KC_3,   KC_4,   KC_5,   KC_MUTE,
    KC_TAB,   KC_Q,    KC_W,    KC_E,   KC_R,   KC_T,   KC_LBRC,
    KC_LSFT,  KC_A,    KC_S,    KC_D,   KC_F,   KC_G,   KC_ESC,
    KC_LCTL,  KC_Z,    KC_X,    KC_C,   KC_V,   KC_B,
                       KC_LGUI,   KC_LALT,
-                               KC_SPC,   KC_BSPC,
-                               KC_LCTL,  LOWER,
-                               KC_LALT,  KC_ESC,
+                               KC_SPC,  KC_BSPC,
+                               LOWER,   KC_LCTL,
+                               KC_LALT, KC_ESC,
         // right hand
-                     QK_BOOT,   KC_6,    KC_7,    KC_8,     KC_9,     KC_0,     KC_MINS,
+                     KC_MUTE, KC_6,    KC_7,    KC_8,     KC_9,     KC_0,     KC_MINS,
                      KC_RBRC, KC_Y,    KC_U,    KC_I,     KC_O,     KC_P,     KC_EQL,
                      KC_MEH,  KC_H,    KC_J,    KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
                               KC_N,    KC_M,    KC_COMM,  KC_DOT,   KC_SLSH,  KC_BSLS,
                                                 ALTSLSH,  KC_SLSH,
-        KC_ENT,  RAISE,
-        KC_RSFT, KC_LALT,
+        KC_TAB,  KC_ENT,
+        KC_RSFT, RAISE,
         KC_PGUP, KC_PGDN),
 
 [_RAISE] = LAYOUT(
@@ -81,7 +81,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         // right hand
                      KC_F7,     KC_F8,     KC_F9,     KC_F10,    KC_F11,    KC_F12,    _______,
                      _______,   _______,   _______,   _______,   _______,   _______,   _______,
-                     _______,   _______,   KC_L,      _______,   _______,   _______,   _______,
+                     QK_BOOT,   _______,   KC_L,      _______,   _______,   _______,   _______,
                                 _______,   _______,   _______,   _______,   _______,   _______,
                                                       _______,   _______,
         KC_DEL, _______,
@@ -92,7 +92,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // left hand
    _______,   _______,   _______,   _______,   _______,   _______,  _______,
    _______,   _______,   _______,   _______,   _______,   _______,  _______,
-   _______,   _______,   _______,   _______,   _______,   _______,  _______,
+   _______,   _______,   _______,   _______,   _______,   _______,  QK_BOOT,
    _______,   _______,   _______,   _______,   _______,   _______,
                          _______,   _______,
                                _______, _______,


### PR DESCRIPTION
Add Dactyl Manuform keyboard

## Description

Add DM as a new keyboard (not handwired).
This matches the handwired DM I printed in 2020.

VIA is set up and working.
VIAL was tested but resulting FW was too big.

Commit will be squashed in my "mine" branch to simplify future rebases with upstream.